### PR TITLE
Fixed reading stored expiry time

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.0.5",
+  "flutterSdkVersion": "3.10.6",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fixed reading expiry time
+
 ## 2.0.0
 
 - Upgrades for Dart 3

--- a/lib/src/oauth.dart
+++ b/lib/src/oauth.dart
@@ -35,7 +35,7 @@ class OAuth extends Interceptor {
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) async {
-    final expiresAtMillis = await storage.read(key: '$name-expiresAt');
+    final expiresAtMillis = await storage.read(key: '$name-expires-at');
     if (expiresAtMillis != null) {
       final expiresAt = DateTime.fromMillisecondsSinceEpoch(
         int.parse(expiresAtMillis),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: oauth_interceptor
 description: Oven-ready Dio interceptor for handling OAuth 2.0
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/netsells/oauth_interceptor
 
 environment:


### PR DESCRIPTION
Expiry time was written to storage in kebab case and read in camel case. Changed to read in kebab case, which should fix issues with automatic token refreshing.